### PR TITLE
fix-double-promotion in fsl_xcvr_trim

### DIFF
--- a/vega_sdk_riscv/middleware/wireless/framework/XCVR/RV32M1/fsl_xcvr_trim.c
+++ b/vega_sdk_riscv/middleware/wireless/framework/XCVR/RV32M1/fsl_xcvr_trim.c
@@ -24,7 +24,7 @@
 #define trunc(x) (uint32_t)(x)
 /* This works correctly only for positive numbers... */
 #define round(x) (uint32_t)((x) + 0.5)
-#define roundf(x) (float)(uint32_t)((x) + 0.5)
+#define roundf(x) (float)(uint32_t)((x) + 0.5f)
 #endif
 
 


### PR DESCRIPTION
Double promotion warnings are generated with the flag -Wdouble-promotion